### PR TITLE
fix: documentation inconsistenciesFix docs inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Click the image below.
 
 ### Streaming Parsing
 - Define schemas for streaming structured outputs using Pydantic-style models.
-- Receive granular, type-safe callbacks (`on_append`, `on_update`, `on_complete`) as tokens stream in.
+- Receive granular, type-safe callbacks (`on_start`, `on_complete`, and `on_append`/`on_update` depending on type) as tokens stream in.
 - Derive Pydantic models from LangDiff models for seamless interop with existing libraries and SDKs like OpenAI SDK.
 
 <table>

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -16,7 +16,7 @@ The parser module contains streaming-aware data types and the core parser for pr
 
 ### Key Features
 
-- **Event Callbacks**: All streaming types support `on_start`, `on_append`, and `on_complete` callbacks
+- **Event Callbacks**: All streaming types support `on_start` and `on_complete` callbacks. Additionally, `Object` supports `on_update`, while `List` and `String` support `on_append`
 - **Type Safety**: Full type hints and generic support for compile-time checking
 - **Pydantic Integration**: Convert streaming models to Pydantic models via `to_pydantic()`
 

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -117,7 +117,7 @@ response_format = BlogPost.to_pydantic()
 
 client = openai.OpenAI()
 with client.chat.completions.stream(
-    model="gpt-4o-mini",
+    model="gpt-5-mini",
     messages=[{"role": "user", "content": "Write a blog post"}],
     response_format=response_format,
 ) as stream:

--- a/docs/api/parser.md
+++ b/docs/api/parser.md
@@ -130,7 +130,7 @@ with client.chat.completions.stream(
 
 ## Event System
 
-All streaming types support three main events:
+All streaming types support common events, with type-specific additional events:
 
 ### on_start()
 Called when streaming begins for a value:
@@ -142,12 +142,25 @@ def on_title_start():
 ```
 
 ### on_append()
-Called as new data is appended:
+Called as new data is appended (supported by `String` and `List` types):
 
 ```python
-@response.content.on_append
+@response.content.on_append  # String type
 def on_content_chunk(chunk: str):
     print(f"New content: {chunk}")
+
+@response.items.on_append  # List type
+def on_item_append(item: ld.String, index: int):
+    print(f"New item at index {index}")
+```
+
+### on_update()
+Called when an object is updated (supported by `Object` type only):
+
+```python
+@response.on_update  # Object type
+def on_object_update(data: dict):
+    print(f"Object updated: {data}")
 ```
 
 ### on_complete()

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ def on_section_append(section: ld.String, index: int):
 # Stream from OpenAI
 client = openai.OpenAI()
 with client.chat.completions.stream(
-    model="gpt-4o-mini",
+    model="gpt-5-mini",
     messages=[{"role": "user", "content": "Write a short article about Python"}],
     response_format=ArticleResponse.to_pydantic(),
 ) as stream:

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ LangDiff provides intelligent partial parsing with granular, type-safe events as
 
 ### Streaming Parsing
 - Define schemas for streaming structured outputs using Pydantic-style models
-- Receive granular, type-safe callbacks (`on_append`, `on_update`, `on_complete`) as tokens stream in
+- Receive granular, type-safe callbacks (`on_start`, `on_complete`, and `on_append`/`on_update` depending on type) as tokens stream in
 - Derive Pydantic models from LangDiff models for seamless interop with existing libraries and SDKs like OpenAI SDK
 
 ### Change Tracking


### PR DESCRIPTION
## Summary

This PR fixes two key documentation inconsistencies that could confuse users:

- **Model name consistency**: Updated documentation examples to use `gpt-5-mini` instead of `gpt-4o-mini` to match the model used in `example.py` and `README.md`
- **Callback event accuracy**: Corrected documentation to accurately reflect which callback events are supported by each streaming type, rather than incorrectly suggesting all types support the same events uniformly

## Changes Made

### Model Name Consistency

- Updated `docs/index.md` and `docs/api/parser.md` to use `gpt-5-mini` in code examples
- Ensures consistency across all documentation and example code

### Callback Event Documentation

- Fixed inaccurate descriptions in `README.md`, `docs/index.md`, and `docs/api/overview.md`
- Added detailed explanations in `docs/api/parser.md` showing which events are supported by each type:
  - **Object**: `on_start`, `on_complete`, `on_update`
  - **List**: `on_start`, `on_complete`, `on_append`
  - **String**: `on_start`, `on_complete`, `on_append`
  - **Atom**: `on_start`, `on_complete`

## Test plan

- [x] All existing tests pass
- [x] Documentation builds without errors
- [x] Code examples in documentation are accurate and consistent